### PR TITLE
ImageManager 구현

### DIFF
--- a/PhotoOverlay.xcodeproj/project.pbxproj
+++ b/PhotoOverlay.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		085CBFB92871AA4F006F2953 /* ImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085CBFB82871AA4F006F2953 /* ImageManager.swift */; };
 		089A8D5428718AAE00AC4873 /* ImageRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089A8D5328718AAE00AC4873 /* ImageRequestable.swift */; };
 		08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78ADE286EE499006296DE /* AppDelegate.swift */; };
 		08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE0286EE499006296DE /* SceneDelegate.swift */; };
@@ -34,6 +35,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		085CBFB82871AA4F006F2953 /* ImageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageManager.swift; sourceTree = "<group>"; };
 		089A8D5328718AAE00AC4873 /* ImageRequestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRequestable.swift; sourceTree = "<group>"; };
 		08C78ADB286EE499006296DE /* PhotoOverlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoOverlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		08C78ADE286EE499006296DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -89,6 +91,7 @@
 			isa = PBXGroup;
 			children = (
 				085CBFB72871AA08006F2953 /* Protocol */,
+				085CBFB82871AA4F006F2953 /* ImageManager.swift */,
 			);
 			path = ImageManager;
 			sourceTree = "<group>";
@@ -412,6 +415,7 @@
 				08C78AE9286EE499006296DE /* PhotoOverlay.xcdatamodeld in Sources */,
 				089A8D5428718AAE00AC4873 /* ImageRequestable.swift in Sources */,
 				08C78AFB2870395F006296DE /* PhotosViewController.swift in Sources */,
+				085CBFB92871AA4F006F2953 /* ImageManager.swift in Sources */,
 				08C78B2028706C0B006296DE /* PhotoFetchable.swift in Sources */,
 				08C78B0E28704483006296DE /* PhotoAuthorizationable.swift in Sources */,
 				08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */,

--- a/PhotoOverlay.xcodeproj/project.pbxproj
+++ b/PhotoOverlay.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		089A8D5428718AAE00AC4873 /* ImageRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089A8D5328718AAE00AC4873 /* ImageRequestable.swift */; };
 		08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78ADE286EE499006296DE /* AppDelegate.swift */; };
 		08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE0286EE499006296DE /* SceneDelegate.swift */; };
 		08C78AE9286EE499006296DE /* PhotoOverlay.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE7286EE499006296DE /* PhotoOverlay.xcdatamodeld */; };
@@ -33,6 +34,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		089A8D5328718AAE00AC4873 /* ImageRequestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRequestable.swift; sourceTree = "<group>"; };
 		08C78ADB286EE499006296DE /* PhotoOverlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoOverlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		08C78ADE286EE499006296DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		08C78AE0286EE499006296DE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -75,6 +77,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		085CBFB72871AA08006F2953 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				089A8D5328718AAE00AC4873 /* ImageRequestable.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
+		089A8D5228718A7F00AC4873 /* ImageManager */ = {
+			isa = PBXGroup;
+			children = (
+				085CBFB72871AA08006F2953 /* Protocol */,
+			);
+			path = ImageManager;
+			sourceTree = "<group>";
+		};
 		08C78AD2286EE499006296DE = {
 			isa = PBXGroup;
 			children = (
@@ -153,6 +171,7 @@
 		08C78AFC287039CC006296DE /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				089A8D5228718A7F00AC4873 /* ImageManager */,
 				08C78AFD287039D2006296DE /* PhotoManager */,
 			);
 			path = Service;
@@ -391,6 +410,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				08C78AE9286EE499006296DE /* PhotoOverlay.xcdatamodeld in Sources */,
+				089A8D5428718AAE00AC4873 /* ImageRequestable.swift in Sources */,
 				08C78AFB2870395F006296DE /* PhotosViewController.swift in Sources */,
 				08C78B2028706C0B006296DE /* PhotoFetchable.swift in Sources */,
 				08C78B0E28704483006296DE /* PhotoAuthorizationable.swift in Sources */,

--- a/PhotoOverlay.xcodeproj/project.pbxproj
+++ b/PhotoOverlay.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		085CBFB92871AA4F006F2953 /* ImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085CBFB82871AA4F006F2953 /* ImageManager.swift */; };
 		085CBFBB2871D145006F2953 /* PHImageManagerable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085CBFBA2871D145006F2953 /* PHImageManagerable.swift */; };
+		085CBFBD2871D236006F2953 /* ImageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085CBFBC2871D236006F2953 /* ImageManagerTests.swift */; };
 		089A8D5428718AAE00AC4873 /* ImageRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089A8D5328718AAE00AC4873 /* ImageRequestable.swift */; };
 		08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78ADE286EE499006296DE /* AppDelegate.swift */; };
 		08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE0286EE499006296DE /* SceneDelegate.swift */; };
@@ -38,6 +39,7 @@
 /* Begin PBXFileReference section */
 		085CBFB82871AA4F006F2953 /* ImageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageManager.swift; sourceTree = "<group>"; };
 		085CBFBA2871D145006F2953 /* PHImageManagerable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PHImageManagerable.swift; sourceTree = "<group>"; };
+		085CBFBC2871D236006F2953 /* ImageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageManagerTests.swift; sourceTree = "<group>"; };
 		089A8D5328718AAE00AC4873 /* ImageRequestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRequestable.swift; sourceTree = "<group>"; };
 		08C78ADB286EE499006296DE /* PhotoOverlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoOverlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		08C78ADE286EE499006296DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -197,6 +199,7 @@
 			children = (
 				08C78B1528704BA2006296DE /* PhotoManagerAuthorizationTests.swift */,
 				08C78B2128708F3E006296DE /* PhotoManagerFetchTests.swift */,
+				085CBFBC2871D236006F2953 /* ImageManagerTests.swift */,
 			);
 			path = PhotoOverlayTests;
 			sourceTree = "<group>";
@@ -432,6 +435,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				085CBFBD2871D236006F2953 /* ImageManagerTests.swift in Sources */,
 				08C78B1628704BA2006296DE /* PhotoManagerAuthorizationTests.swift in Sources */,
 				08C78B2228708F3E006296DE /* PhotoManagerFetchTests.swift in Sources */,
 			);

--- a/PhotoOverlay.xcodeproj/project.pbxproj
+++ b/PhotoOverlay.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		085CBFB92871AA4F006F2953 /* ImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085CBFB82871AA4F006F2953 /* ImageManager.swift */; };
+		085CBFBB2871D145006F2953 /* PHImageManagerable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085CBFBA2871D145006F2953 /* PHImageManagerable.swift */; };
 		089A8D5428718AAE00AC4873 /* ImageRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089A8D5328718AAE00AC4873 /* ImageRequestable.swift */; };
 		08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78ADE286EE499006296DE /* AppDelegate.swift */; };
 		08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE0286EE499006296DE /* SceneDelegate.swift */; };
@@ -36,6 +37,7 @@
 
 /* Begin PBXFileReference section */
 		085CBFB82871AA4F006F2953 /* ImageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageManager.swift; sourceTree = "<group>"; };
+		085CBFBA2871D145006F2953 /* PHImageManagerable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PHImageManagerable.swift; sourceTree = "<group>"; };
 		089A8D5328718AAE00AC4873 /* ImageRequestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRequestable.swift; sourceTree = "<group>"; };
 		08C78ADB286EE499006296DE /* PhotoOverlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoOverlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		08C78ADE286EE499006296DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -83,6 +85,7 @@
 			isa = PBXGroup;
 			children = (
 				089A8D5328718AAE00AC4873 /* ImageRequestable.swift */,
+				085CBFBA2871D145006F2953 /* PHImageManagerable.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -417,6 +420,7 @@
 				08C78AFB2870395F006296DE /* PhotosViewController.swift in Sources */,
 				085CBFB92871AA4F006F2953 /* ImageManager.swift in Sources */,
 				08C78B2028706C0B006296DE /* PhotoFetchable.swift in Sources */,
+				085CBFBB2871D145006F2953 /* PHImageManagerable.swift in Sources */,
 				08C78B0E28704483006296DE /* PhotoAuthorizationable.swift in Sources */,
 				08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */,
 				08C78AFF287039F7006296DE /* PhotoManager.swift in Sources */,

--- a/PhotoOverlay.xcodeproj/xcuserdata/hwangjeha.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/PhotoOverlay.xcodeproj/xcuserdata/hwangjeha.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -10,5 +10,18 @@
 			<integer>6</integer>
 		</dict>
 	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>08C78ADA286EE499006296DE</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>08C78B1228704BA2006296DE</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/PhotoOverlay/Presentation/View/PhotosViewController.swift
+++ b/PhotoOverlay/Presentation/View/PhotosViewController.swift
@@ -8,9 +8,47 @@
 import UIKit
 
 import RxSwift
+import SnapKit
 
 final class PhotosViewController: UIViewController {
-
+    
+    // MARK: - Views
+    
+    private let imageView1: UIImageView = {
+        let imageView = UIImageView()
+        return imageView
+    }()
+    private let imageView2: UIImageView = {
+        let imageView = UIImageView()
+        return imageView
+    }()
+    private let imageView3: UIImageView = {
+        let imageView = UIImageView()
+        return imageView
+    }()
+    private let imageView4: UIImageView = {
+        let imageView = UIImageView()
+        return imageView
+    }()
+    private let imageView5: UIImageView = {
+        let imageView = UIImageView()
+        return imageView
+    }()
+    private let imageView6: UIImageView = {
+        let imageView = UIImageView()
+        return imageView
+    }()
+    
+    private lazy var imageViews: [UIImageView] = [
+        imageView1,
+        imageView2,
+        imageView3,
+        imageView4,
+        imageView5,
+        imageView6
+    ]
+    
+    
     // MARK: - Properties
     
     private var disposeBag = DisposeBag()
@@ -19,6 +57,7 @@ final class PhotosViewController: UIViewController {
         super.viewDidLoad()
         
         configureView()
+        configureSubViews()
         
         PhotoManager.shared.checkPhotoLibraryAuthorization()
             .filter { $0 != .authorized }
@@ -29,11 +68,42 @@ final class PhotosViewController: UIViewController {
                 print(status)
             })
             .disposed(by: disposeBag)
+        
+        PhotoManager.shared.fetch()
+            .flatMap { assets -> Observable<[UIImage?]> in
+                let dd = assets.map { asset in
+                    ImageManager.shard.requestImage(asset: asset, contentMode: .aspectFit)
+                }
+                return Observable.combineLatest(dd)
+            }
+            .subscribe(onNext: { [weak self] images in
+                for (index, image) in images.enumerated() {
+                    self?.imageViews[index].image = image
+                }
+            })
+            .disposed(by: disposeBag)
     }
 }
 
 extension PhotosViewController {
     private func configureView() {
         view.backgroundColor = .systemBackground
+    }
+    
+    private func configureSubViews() {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.distribution = .fillEqually
+        stackView.spacing = 8
+        
+        imageViews.forEach {
+            stackView.addArrangedSubview($0)
+        }
+        
+        view.addSubview(stackView)
+        
+        stackView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
     }
 }

--- a/PhotoOverlay/Service/ImageManager/ImageManager.swift
+++ b/PhotoOverlay/Service/ImageManager/ImageManager.swift
@@ -1,0 +1,23 @@
+//
+//  ImageManager.swift
+//  PhotoOverlay
+//
+//  Created by 황제하 on 2022/07/03.
+//
+
+import UIKit
+import Photos
+
+import RxSwift
+
+final class ImageManager {
+    static let shard: ImageManager = ImageManager()
+    
+    private init() { }
+}
+
+extension ImageManager: ImageRequestable {
+    func requestImage(asset: PHAsset, contentMOde: UIView.ContentMode) -> Observable<UIImage> {
+        return .empty()
+    }
+}

--- a/PhotoOverlay/Service/ImageManager/ImageManager.swift
+++ b/PhotoOverlay/Service/ImageManager/ImageManager.swift
@@ -13,10 +13,10 @@ import RxSwift
 final class ImageManager {
     static let shard: ImageManager = ImageManager()
     
-    let phImageManager: PHImageManager
+    let phImageManager: PHImageManagerable
     
     private init(
-        phImageManager: PHImageManager = PHImageManager.default()
+        phImageManager: PHImageManagerable = PHImageManager.default()
     ) {
         self.phImageManager = phImageManager
     }

--- a/PhotoOverlay/Service/ImageManager/ImageManager.swift
+++ b/PhotoOverlay/Service/ImageManager/ImageManager.swift
@@ -22,19 +22,22 @@ extension ImageManager: ImageRequestable {
         contentMode: PHImageContentMode
     ) -> Observable<UIImage?> {
         return Observable<UIImage?>.create { emitter in
+            
             let targetSize = CGSize(width: asset.pixelWidth, height: asset.pixelHeight)
             
-            PHImageManager.default().requestImage(
+            let manager = PHImageManager.default()
+            let requestID = manager.requestImage(
                 for: asset,
                 targetSize: targetSize,
                 contentMode: contentMode,
                 options: nil
             ) { (image, _) in
                 emitter.onNext(image)
-                emitter.onCompleted()
             }
             
-            return Disposables.create()
+            return Disposables.create {
+                manager.cancelImageRequest(requestID)
+            }
         }
     }
 }

--- a/PhotoOverlay/Service/ImageManager/ImageManager.swift
+++ b/PhotoOverlay/Service/ImageManager/ImageManager.swift
@@ -13,7 +13,13 @@ import RxSwift
 final class ImageManager {
     static let shard: ImageManager = ImageManager()
     
-    private init() { }
+    let phImageManager: PHImageManager
+    
+    private init(
+        phImageManager: PHImageManager = PHImageManager.default()
+    ) {
+        self.phImageManager = phImageManager
+    }
 }
 
 extension ImageManager: ImageRequestable {
@@ -21,12 +27,10 @@ extension ImageManager: ImageRequestable {
         asset: PHAsset,
         contentMode: PHImageContentMode
     ) -> Observable<UIImage?> {
-        return Observable<UIImage?>.create { emitter in
-            
+        return Observable<UIImage?>.create { [weak self] emitter in
             let targetSize = CGSize(width: asset.pixelWidth, height: asset.pixelHeight)
             
-            let manager = PHImageManager.default()
-            let requestID = manager.requestImage(
+            let requestID = self?.phImageManager.requestImage(
                 for: asset,
                 targetSize: targetSize,
                 contentMode: contentMode,
@@ -36,7 +40,7 @@ extension ImageManager: ImageRequestable {
             }
             
             return Disposables.create {
-                manager.cancelImageRequest(requestID)
+                requestID.map { self?.phImageManager.cancelImageRequest($0) }
             }
         }
     }

--- a/PhotoOverlay/Service/ImageManager/ImageManager.swift
+++ b/PhotoOverlay/Service/ImageManager/ImageManager.swift
@@ -17,7 +17,24 @@ final class ImageManager {
 }
 
 extension ImageManager: ImageRequestable {
-    func requestImage(asset: PHAsset, contentMOde: UIView.ContentMode) -> Observable<UIImage> {
-        return .empty()
+    func requestImage(
+        asset: PHAsset,
+        contentMode: PHImageContentMode
+    ) -> Observable<UIImage?> {
+        return Observable<UIImage?>.create { emitter in
+            let targetSize = CGSize(width: asset.pixelWidth, height: asset.pixelHeight)
+            
+            PHImageManager.default().requestImage(
+                for: asset,
+                targetSize: targetSize,
+                contentMode: contentMode,
+                options: nil
+            ) { (image, _) in
+                emitter.onNext(image)
+                emitter.onCompleted()
+            }
+            
+            return Disposables.create()
+        }
     }
 }

--- a/PhotoOverlay/Service/ImageManager/ImageManager.swift
+++ b/PhotoOverlay/Service/ImageManager/ImageManager.swift
@@ -15,7 +15,7 @@ final class ImageManager {
     
     let phImageManager: PHImageManagerable
     
-    private init(
+    init(
         phImageManager: PHImageManagerable = PHImageManager.default()
     ) {
         self.phImageManager = phImageManager

--- a/PhotoOverlay/Service/ImageManager/Protocol/ImageRequestable.swift
+++ b/PhotoOverlay/Service/ImageManager/Protocol/ImageRequestable.swift
@@ -14,6 +14,6 @@ protocol ImageRequestable {
     // PHAsset -> UIImage 요청 메서드
     func requestImage(
         asset: PHAsset,
-        contentMOde: UIImageView.ContentMode
-    ) -> Observable<UIImage>
+        contentMode: PHImageContentMode
+    ) -> Observable<UIImage?>
 }

--- a/PhotoOverlay/Service/ImageManager/Protocol/ImageRequestable.swift
+++ b/PhotoOverlay/Service/ImageManager/Protocol/ImageRequestable.swift
@@ -1,0 +1,19 @@
+//
+//  ImageRequestable.swift
+//  PhotoOverlay
+//
+//  Created by 황제하 on 2022/07/03.
+//
+
+import UIKit
+import Photos
+
+import RxSwift
+
+protocol ImageRequestable {
+    // PHAsset -> UIImage 요청 메서드
+    func requestImage(
+        asset: PHAsset,
+        contentMOde: UIImageView.ContentMode
+    ) -> Observable<UIImage>
+}

--- a/PhotoOverlay/Service/ImageManager/Protocol/PHImageManagerable.swift
+++ b/PhotoOverlay/Service/ImageManager/Protocol/PHImageManagerable.swift
@@ -1,0 +1,24 @@
+//
+//  PHImageManagerable.swift
+//  PhotoOverlay
+//
+//  Created by 황제하 on 2022/07/03.
+//
+
+import Photos
+import UIKit
+
+protocol PHImageManagerable {
+    func requestImage(
+        for asset: PHAsset,
+        targetSize: CGSize,
+        contentMode: PHImageContentMode,
+        options: PHImageRequestOptions?,
+        resultHandler: @escaping (UIImage?, [AnyHashable : Any]?) -> Void
+    ) -> PHImageRequestID
+    
+    func cancelImageRequest(_ requestID: PHImageRequestID)
+}
+
+extension PHImageManager: PHImageManagerable { }
+

--- a/PhotoOverlayTests/ImageManagerTests.swift
+++ b/PhotoOverlayTests/ImageManagerTests.swift
@@ -6,6 +6,27 @@
 //
 
 import XCTest
+import Photos
+@testable import PhotoOverlay
+
+import RxSwift
+
+final class MockPHImageManager: PHImageManagerable {
+    func requestImage(
+        for asset: PHAsset,
+        targetSize: CGSize,
+        contentMode: PHImageContentMode,
+        options: PHImageRequestOptions?,
+        resultHandler: @escaping (UIImage?, [AnyHashable: Any]?) -> Void
+    ) -> PHImageRequestID {
+        resultHandler(UIImage(), nil)
+        return 0
+    }
+    
+    func cancelImageRequest(_ requestID: PHImageRequestID) {
+        print("\(requestID) 취소")
+    }
+}
 
 final class ImageManagerTests: XCTestCase {
 

--- a/PhotoOverlayTests/ImageManagerTests.swift
+++ b/PhotoOverlayTests/ImageManagerTests.swift
@@ -1,0 +1,23 @@
+//
+//  ImageManagerTests.swift
+//  PhotoOverlayTests
+//
+//  Created by 황제하 on 2022/07/03.
+//
+
+import XCTest
+
+final class ImageManagerTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        
+    }
+
+    override func tearDownWithError() throws {
+        
+    }
+
+    func testExample() throws {
+        
+    }
+}

--- a/PhotoOverlayTests/ImageManagerTests.swift
+++ b/PhotoOverlayTests/ImageManagerTests.swift
@@ -30,15 +30,40 @@ final class MockPHImageManager: PHImageManagerable {
 
 final class ImageManagerTests: XCTestCase {
 
+    private var sut: ImageManager!
+    private var disposeBag = DisposeBag()
+    
     override func setUpWithError() throws {
-        
+        sut = ImageManager()
     }
 
     override func tearDownWithError() throws {
-        
+        sut = nil
+        disposeBag = DisposeBag()
     }
 
-    func testExample() throws {
+    func test_Asset에서_이미지를_정상적으로_가져오는가() throws {
+        // given
+        // 앨범의 Asset을 정상적으로 가져온 상태
+        sut = ImageManager(phImageManager: MockPHImageManager())
+        let asset = PHAsset()
         
+        let expectation = XCTestExpectation(description: "Asset에서 이미지를 정상적으로 가져오는가")
+        
+        // when
+        // Asset에서 이미지를 정상적으로 가져오는가?
+        var result: UIImage?
+        sut.requestImage(asset: asset, contentMode: .aspectFit)
+            .subscribe(onNext: { image in
+                result = image
+                expectation.fulfill()
+            })
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 5)
+        
+        // then
+        // 가져온 이미지가 nil이 아닌가
+        XCTAssertNotNil(result)
     }
 }


### PR DESCRIPTION
### 구현
  - **class** ImageManager : ImageRequestable 프로토콜 채택
    - requestImage(asset: PHAsset, contentMode: PHImageContentMode)
      - PHAsset에서 이미지를 요청하는 메서드
  - **protocol** ImageRequestable 
  - **protocol** PHImageManagerable
    - PHImageManager에 채택, Unit Test시 Mock 객체로 변경하기 위함.

### 테스트
  - ImageManagerTests
    - Asset에서 이미지를 정상적으로 가져오는가