### PR TITLE
앨범 리스트 ViewModel 구현

### DIFF
--- a/PhotoOverlay.xcodeproj/project.pbxproj
+++ b/PhotoOverlay.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		08A1D4B928753B1300490129 /* AlbumListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4B828753B1300490129 /* AlbumListViewController.swift */; };
 		08A1D4BB28753B5800490129 /* AlbumListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4BA28753B5800490129 /* AlbumListView.swift */; };
 		08A1D4BD287550C000490129 /* AlbumListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4BC287550C000490129 /* AlbumListTableViewCell.swift */; };
+		08A1D4C02875636200490129 /* AlbumListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4BF2875636200490129 /* AlbumListViewModel.swift */; };
 		08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78ADE286EE499006296DE /* AppDelegate.swift */; };
 		08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE0286EE499006296DE /* SceneDelegate.swift */; };
 		08C78AE9286EE499006296DE /* PhotoOverlay.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE7286EE499006296DE /* PhotoOverlay.xcdatamodeld */; };
@@ -71,6 +72,7 @@
 		08A1D4B828753B1300490129 /* AlbumListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListViewController.swift; sourceTree = "<group>"; };
 		08A1D4BA28753B5800490129 /* AlbumListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListView.swift; sourceTree = "<group>"; };
 		08A1D4BC287550C000490129 /* AlbumListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListTableViewCell.swift; sourceTree = "<group>"; };
+		08A1D4BF2875636200490129 /* AlbumListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListViewModel.swift; sourceTree = "<group>"; };
 		08C78ADB286EE499006296DE /* PhotoOverlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoOverlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		08C78ADE286EE499006296DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		08C78AE0286EE499006296DE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -219,6 +221,7 @@
 		08A1D4B628753AE800490129 /* AlbumList */ = {
 			isa = PBXGroup;
 			children = (
+				08A1D4BE287562B800490129 /* ViewModel */,
 				08A1D4B728753AF400490129 /* View */,
 			);
 			path = AlbumList;
@@ -232,6 +235,14 @@
 				08A1D4BC287550C000490129 /* AlbumListTableViewCell.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		08A1D4BE287562B800490129 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				08A1D4BF2875636200490129 /* AlbumListViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		08C78AD2286EE499006296DE = {
@@ -291,9 +302,9 @@
 		08C78AF728703916006296DE /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
-				08A1D4B628753AE800490129 /* AlbumList */,
 				08A1D4A02873FD1400490129 /* Common */,
 				08A1D49B2873FC7400490129 /* PhotoList */,
+				08A1D4B628753AE800490129 /* AlbumList */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -575,6 +586,7 @@
 				08A1D49F2873FD0D00490129 /* ViewModel.swift in Sources */,
 				08A1D4BD287550C000490129 /* AlbumListTableViewCell.swift in Sources */,
 				08A1D4BB28753B5800490129 /* AlbumListView.swift in Sources */,
+				08A1D4C02875636200490129 /* AlbumListViewModel.swift in Sources */,
 				08A1D4B3287411D300490129 /* PhotoItem.swift in Sources */,
 				08A1D4B928753B1300490129 /* AlbumListViewController.swift in Sources */,
 				08C78B0E28704483006296DE /* PhotoAuthorizationable.swift in Sources */,

--- a/PhotoOverlay.xcodeproj/project.pbxproj
+++ b/PhotoOverlay.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		08A1D4BD287550C000490129 /* AlbumListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4BC287550C000490129 /* AlbumListTableViewCell.swift */; };
 		08A1D4C02875636200490129 /* AlbumListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4BF2875636200490129 /* AlbumListViewModel.swift */; };
 		08A1D4C2287563D800490129 /* DefaultAlbumRepositoryt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4C1287563D800490129 /* DefaultAlbumRepositoryt.swift */; };
+		08A1D4C42875666200490129 /* AlbumUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4C32875666200490129 /* AlbumUseCase.swift */; };
 		08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78ADE286EE499006296DE /* AppDelegate.swift */; };
 		08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE0286EE499006296DE /* SceneDelegate.swift */; };
 		08C78AE9286EE499006296DE /* PhotoOverlay.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE7286EE499006296DE /* PhotoOverlay.xcdatamodeld */; };
@@ -75,6 +76,7 @@
 		08A1D4BC287550C000490129 /* AlbumListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListTableViewCell.swift; sourceTree = "<group>"; };
 		08A1D4BF2875636200490129 /* AlbumListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListViewModel.swift; sourceTree = "<group>"; };
 		08A1D4C1287563D800490129 /* DefaultAlbumRepositoryt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAlbumRepositoryt.swift; sourceTree = "<group>"; };
+		08A1D4C32875666200490129 /* AlbumUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumUseCase.swift; sourceTree = "<group>"; };
 		08C78ADB286EE499006296DE /* PhotoOverlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoOverlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		08C78ADE286EE499006296DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		08C78AE0286EE499006296DE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -192,6 +194,7 @@
 			isa = PBXGroup;
 			children = (
 				08A1D4A72874041900490129 /* PhotoUseCase.swift */,
+				08A1D4C32875666200490129 /* AlbumUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -588,6 +591,7 @@
 				0817A9B12872CDC300C821DD /* PhotoListCollectionViewCell.swift in Sources */,
 				08A1D49F2873FD0D00490129 /* ViewModel.swift in Sources */,
 				08A1D4BD287550C000490129 /* AlbumListTableViewCell.swift in Sources */,
+				08A1D4C42875666200490129 /* AlbumUseCase.swift in Sources */,
 				08A1D4BB28753B5800490129 /* AlbumListView.swift in Sources */,
 				08A1D4C02875636200490129 /* AlbumListViewModel.swift in Sources */,
 				08A1D4B3287411D300490129 /* PhotoItem.swift in Sources */,

--- a/PhotoOverlay.xcodeproj/project.pbxproj
+++ b/PhotoOverlay.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		08A1D4C02875636200490129 /* AlbumListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4BF2875636200490129 /* AlbumListViewModel.swift */; };
 		08A1D4C2287563D800490129 /* DefaultAlbumRepositoryt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4C1287563D800490129 /* DefaultAlbumRepositoryt.swift */; };
 		08A1D4C42875666200490129 /* AlbumUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4C32875666200490129 /* AlbumUseCase.swift */; };
+		08A1D4C628756E9A00490129 /* AlbumRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4C528756E9A00490129 /* AlbumRepository.swift */; };
 		08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78ADE286EE499006296DE /* AppDelegate.swift */; };
 		08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE0286EE499006296DE /* SceneDelegate.swift */; };
 		08C78AE9286EE499006296DE /* PhotoOverlay.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE7286EE499006296DE /* PhotoOverlay.xcdatamodeld */; };
@@ -77,6 +78,7 @@
 		08A1D4BF2875636200490129 /* AlbumListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListViewModel.swift; sourceTree = "<group>"; };
 		08A1D4C1287563D800490129 /* DefaultAlbumRepositoryt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAlbumRepositoryt.swift; sourceTree = "<group>"; };
 		08A1D4C32875666200490129 /* AlbumUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumUseCase.swift; sourceTree = "<group>"; };
+		08A1D4C528756E9A00490129 /* AlbumRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumRepository.swift; sourceTree = "<group>"; };
 		08C78ADB286EE499006296DE /* PhotoOverlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoOverlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		08C78ADE286EE499006296DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		08C78AE0286EE499006296DE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -211,6 +213,7 @@
 			isa = PBXGroup;
 			children = (
 				08A1D4AB287404DE00490129 /* PhotoRepository.swift */,
+				08A1D4C528756E9A00490129 /* AlbumRepository.swift */,
 			);
 			path = Repositorise;
 			sourceTree = "<group>";
@@ -578,6 +581,7 @@
 			files = (
 				08C78AE9286EE499006296DE /* PhotoOverlay.xcdatamodeld in Sources */,
 				089A8D5428718AAE00AC4873 /* ImageRequestable.swift in Sources */,
+				08A1D4C628756E9A00490129 /* AlbumRepository.swift in Sources */,
 				08A1D4AF287408C500490129 /* Album.swift in Sources */,
 				08C78AFB2870395F006296DE /* PhotosViewController.swift in Sources */,
 				0817A9B42872DB7500C821DD /* UIFont+extension.swift in Sources */,

--- a/PhotoOverlay.xcodeproj/project.pbxproj
+++ b/PhotoOverlay.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		08A1D4BB28753B5800490129 /* AlbumListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4BA28753B5800490129 /* AlbumListView.swift */; };
 		08A1D4BD287550C000490129 /* AlbumListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4BC287550C000490129 /* AlbumListTableViewCell.swift */; };
 		08A1D4C02875636200490129 /* AlbumListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4BF2875636200490129 /* AlbumListViewModel.swift */; };
+		08A1D4C2287563D800490129 /* DefaultAlbumRepositoryt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4C1287563D800490129 /* DefaultAlbumRepositoryt.swift */; };
 		08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78ADE286EE499006296DE /* AppDelegate.swift */; };
 		08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE0286EE499006296DE /* SceneDelegate.swift */; };
 		08C78AE9286EE499006296DE /* PhotoOverlay.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE7286EE499006296DE /* PhotoOverlay.xcdatamodeld */; };
@@ -73,6 +74,7 @@
 		08A1D4BA28753B5800490129 /* AlbumListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListView.swift; sourceTree = "<group>"; };
 		08A1D4BC287550C000490129 /* AlbumListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListTableViewCell.swift; sourceTree = "<group>"; };
 		08A1D4BF2875636200490129 /* AlbumListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListViewModel.swift; sourceTree = "<group>"; };
+		08A1D4C1287563D800490129 /* DefaultAlbumRepositoryt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAlbumRepositoryt.swift; sourceTree = "<group>"; };
 		08C78ADB286EE499006296DE /* PhotoOverlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoOverlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		08C78ADE286EE499006296DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		08C78AE0286EE499006296DE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 			isa = PBXGroup;
 			children = (
 				08A1D4A32874010F00490129 /* DefaultPhotoRepository.swift */,
+				08A1D4C1287563D800490129 /* DefaultAlbumRepositoryt.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -593,6 +596,7 @@
 				08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */,
 				08C78AFF287039F7006296DE /* PhotoManager.swift in Sources */,
 				08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */,
+				08A1D4C2287563D800490129 /* DefaultAlbumRepositoryt.swift in Sources */,
 				08A1D4AC287404DE00490129 /* PhotoRepository.swift in Sources */,
 				08A1D4B52874127F00490129 /* UIViewController+Rx.swift in Sources */,
 				08A1D4A82874041900490129 /* PhotoUseCase.swift in Sources */,

--- a/PhotoOverlay.xcodeproj/project.pbxproj
+++ b/PhotoOverlay.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		08A1D4C2287563D800490129 /* DefaultAlbumRepositoryt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4C1287563D800490129 /* DefaultAlbumRepositoryt.swift */; };
 		08A1D4C42875666200490129 /* AlbumUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4C32875666200490129 /* AlbumUseCase.swift */; };
 		08A1D4C628756E9A00490129 /* AlbumRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4C528756E9A00490129 /* AlbumRepository.swift */; };
+		08A1D4C82875704400490129 /* AlbumItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D4C72875704400490129 /* AlbumItem.swift */; };
 		08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78ADE286EE499006296DE /* AppDelegate.swift */; };
 		08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE0286EE499006296DE /* SceneDelegate.swift */; };
 		08C78AE9286EE499006296DE /* PhotoOverlay.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE7286EE499006296DE /* PhotoOverlay.xcdatamodeld */; };
@@ -79,6 +80,7 @@
 		08A1D4C1287563D800490129 /* DefaultAlbumRepositoryt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAlbumRepositoryt.swift; sourceTree = "<group>"; };
 		08A1D4C32875666200490129 /* AlbumUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumUseCase.swift; sourceTree = "<group>"; };
 		08A1D4C528756E9A00490129 /* AlbumRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumRepository.swift; sourceTree = "<group>"; };
+		08A1D4C72875704400490129 /* AlbumItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumItem.swift; sourceTree = "<group>"; };
 		08C78ADB286EE499006296DE /* PhotoOverlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoOverlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		08C78ADE286EE499006296DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		08C78AE0286EE499006296DE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 			isa = PBXGroup;
 			children = (
 				08A1D4BF2875636200490129 /* AlbumListViewModel.swift */,
+				08A1D4C72875704400490129 /* AlbumItem.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -605,6 +608,7 @@
 				08C78AFF287039F7006296DE /* PhotoManager.swift in Sources */,
 				08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */,
 				08A1D4C2287563D800490129 /* DefaultAlbumRepositoryt.swift in Sources */,
+				08A1D4C82875704400490129 /* AlbumItem.swift in Sources */,
 				08A1D4AC287404DE00490129 /* PhotoRepository.swift in Sources */,
 				08A1D4B52874127F00490129 /* UIViewController+Rx.swift in Sources */,
 				08A1D4A82874041900490129 /* PhotoUseCase.swift in Sources */,

--- a/PhotoOverlay/Data/Repositories/DefaultAlbumRepositoryt.swift
+++ b/PhotoOverlay/Data/Repositories/DefaultAlbumRepositoryt.swift
@@ -1,0 +1,25 @@
+//
+//  DefaultAlbumRepositort.swift
+//  PhotoOverlay
+//
+//  Created by 황제하 on 2022/07/06.
+//
+
+import Foundation
+import Photos
+
+import RxSwift
+
+final class DefaultAlbumRepository {
+    let photoManager: PhotoFetchable
+    
+    init(photoManager: PhotoFetchable = PhotoManager.shared) {
+        self.photoManager = photoManager
+    }
+}
+
+extension DefaultAlbumRepository {
+    func fetch() -> Observable<[PHAssetCollection]> {
+        return photoManager.fetchCollections()
+    }
+}

--- a/PhotoOverlay/Data/Repositories/DefaultAlbumRepositoryt.swift
+++ b/PhotoOverlay/Data/Repositories/DefaultAlbumRepositoryt.swift
@@ -29,4 +29,11 @@ extension DefaultAlbumRepository: AlbumRepository {
     ) -> Observable<PHAsset?> {
         return photoManager.fetchFirst(in: collection, with: mediaType)
     }
+    
+    func fetchFirst(
+        mediaType: PHAssetMediaType
+    ) -> Observable<PHAsset?> {
+        return photoManager.fetch(mediaType: .image)
+            .map { $0.first }
+    }
 }

--- a/PhotoOverlay/Data/Repositories/DefaultAlbumRepositoryt.swift
+++ b/PhotoOverlay/Data/Repositories/DefaultAlbumRepositoryt.swift
@@ -18,8 +18,15 @@ final class DefaultAlbumRepository {
     }
 }
 
-extension DefaultAlbumRepository {
+extension DefaultAlbumRepository: AlbumRepository {
     func fetch() -> Observable<[PHAssetCollection]> {
         return photoManager.fetchCollections()
+    }
+    
+    func fetchFirst(
+        in collection: PHAssetCollection,
+        with mediaType: PHAssetMediaType
+    ) -> Observable<PHAsset?> {
+        return photoManager.fetchFirst(in: collection, with: mediaType)
     }
 }

--- a/PhotoOverlay/Data/Repositories/DefaultAlbumRepositoryt.swift
+++ b/PhotoOverlay/Data/Repositories/DefaultAlbumRepositoryt.swift
@@ -34,6 +34,6 @@ extension DefaultAlbumRepository: AlbumRepository {
         mediaType: PHAssetMediaType
     ) -> Observable<PHAsset?> {
         return photoManager.fetch(mediaType: .image)
-            .map { $0.first }
+            .map { $0.last }
     }
 }

--- a/PhotoOverlay/Data/Repositories/DefaultPhotoRepository.swift
+++ b/PhotoOverlay/Data/Repositories/DefaultPhotoRepository.swift
@@ -10,7 +10,7 @@ import Photos
 
 import RxSwift
 
-final class DefaultPhotoRepository: PhotoRepository {
+final class DefaultPhotoRepository {
     let photoManager: PhotoFetchable
     
     init(photoManager: PhotoFetchable = PhotoManager.shared) {
@@ -18,7 +18,7 @@ final class DefaultPhotoRepository: PhotoRepository {
     }
 }
 
-extension DefaultPhotoRepository {
+extension DefaultPhotoRepository: PhotoRepository {
     func fetch() -> Observable<[PHAsset]> {
         return photoManager.fetch(mediaType: .image)
     }

--- a/PhotoOverlay/Domain/Entities/Album.swift
+++ b/PhotoOverlay/Domain/Entities/Album.swift
@@ -5,11 +5,22 @@
 //  Created by 황제하 on 2022/07/05.
 //
 
-import Foundation
+import UIKit
 import Photos
 
 struct Album {
     let title: String?
     var thumbnail: UIImage?
     var assetCollection: PHAssetCollection?
+}
+
+// MARK: - Mapping
+
+extension Album {
+    func toItem() -> AlbumItem {
+        return AlbumItem(
+            title: title ?? "",
+            thumbnailImage: thumbnail
+        )
+    }
 }

--- a/PhotoOverlay/Domain/Entities/Album.swift
+++ b/PhotoOverlay/Domain/Entities/Album.swift
@@ -9,6 +9,7 @@ import Foundation
 import Photos
 
 struct Album {
-    let title: String
-    var asset: PHAssetCollection?
+    let title: String?
+    var thumbnail: UIImage?
+    var assetCollection: PHAssetCollection?
 }

--- a/PhotoOverlay/Domain/Entities/Photos.swift
+++ b/PhotoOverlay/Domain/Entities/Photos.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 struct Photos {
-    let photos: [UIImage]
+    let photos: [UIImage?]
 }
 
 // MARK: - Mapping

--- a/PhotoOverlay/Domain/Interfaces/Repositorise/AlbumRepository.swift
+++ b/PhotoOverlay/Domain/Interfaces/Repositorise/AlbumRepository.swift
@@ -1,0 +1,20 @@
+//
+//  AlbumRepository.swift
+//  PhotoOverlay
+//
+//  Created by 황제하 on 2022/07/06.
+//
+
+import Foundation
+import Photos
+
+import RxSwift
+
+protocol AlbumRepository {
+    func fetch() -> Observable<[PHAssetCollection]>
+    
+    func fetchFirst(
+        in collection: PHAssetCollection,
+        with mediaType: PHAssetMediaType
+    ) -> Observable<PHAsset?>
+}

--- a/PhotoOverlay/Domain/Interfaces/Repositorise/AlbumRepository.swift
+++ b/PhotoOverlay/Domain/Interfaces/Repositorise/AlbumRepository.swift
@@ -17,4 +17,8 @@ protocol AlbumRepository {
         in collection: PHAssetCollection,
         with mediaType: PHAssetMediaType
     ) -> Observable<PHAsset?>
+    
+    func fetchFirst(
+        mediaType: PHAssetMediaType
+    ) -> Observable<PHAsset?>
 }

--- a/PhotoOverlay/Domain/UseCase/AlbumUseCase.swift
+++ b/PhotoOverlay/Domain/UseCase/AlbumUseCase.swift
@@ -1,0 +1,49 @@
+//
+//  AlbumUseCase.swift
+//  PhotoOverlay
+//
+//  Created by 황제하 on 2022/07/06.
+//
+
+import Foundation
+import Photos
+
+import RxSwift
+
+final class AlbumUseCase {
+    let albumRepository: DefaultAlbumRepository
+    
+    init(albumRepository: DefaultAlbumRepository = DefaultAlbumRepository()) {
+        self.albumRepository = albumRepository
+    }
+}
+
+extension AlbumUseCase {
+    func fetch() -> Observable<[Album]> {
+        return albumRepository.fetch()
+            .flatMap { collections -> Observable<[Album]> in
+                let observables = collections.map { collection -> Observable<Album> in
+                    
+                    let thumbnail = PhotoManager.shared.fetchFirst(in: collection)
+                        .flatMap { asset in
+                            ImageManager.shard.requestImage(
+                                asset: asset!,
+                                contentMode: .aspectFit
+                            )
+                        }
+                    
+                    let title = Observable<String?>.just(collection.localizedTitle)
+                    
+                    return Observable.combineLatest(title, thumbnail).map {
+                        Album(
+                            title: $0,
+                            thumbnail: $1,
+                            assetCollection: collection
+                        )
+                    }
+                }
+                
+                return Observable.combineLatest(observables)
+            }
+    }
+}

--- a/PhotoOverlay/Domain/UseCase/AlbumUseCase.swift
+++ b/PhotoOverlay/Domain/UseCase/AlbumUseCase.swift
@@ -19,7 +19,7 @@ final class AlbumUseCase {
 }
 
 extension AlbumUseCase {
-    func fetch() -> Observable<[Album]> {
+    func fetchAlbum() -> Observable<[Album]> {
         return albumRepository.fetch()
             .withUnretained(self)
             .flatMap { (owner, collections) -> Observable<[Album]> in
@@ -28,7 +28,7 @@ extension AlbumUseCase {
                     let thumbnail = owner.albumRepository.fetchFirst(in: collection, with: .image)
                         .flatMap { asset in
                             ImageManager.shard.requestImage(
-                                asset: asset!,
+                                asset: asset,
                                 contentMode: .aspectFit
                             )
                         }

--- a/PhotoOverlay/Domain/UseCase/AlbumUseCase.swift
+++ b/PhotoOverlay/Domain/UseCase/AlbumUseCase.swift
@@ -47,4 +47,18 @@ extension AlbumUseCase {
                 return Observable.combineLatest(observables)
             }
     }
+    
+    func fetchAllPhotosAlbum() -> Observable<Album> {
+        return albumRepository.fetchFirst(mediaType: .image)
+            .flatMap { asset -> Observable<UIImage?> in
+                ImageManager.shard.requestImage(asset: asset, contentMode: .aspectFit)
+            }
+            .map { image in
+                Album(
+                    title: "All Photos",
+                    thumbnail: image,
+                    assetCollection: nil
+                )
+            }
+    }
 }

--- a/PhotoOverlay/Domain/UseCase/PhotoUseCase.swift
+++ b/PhotoOverlay/Domain/UseCase/PhotoUseCase.swift
@@ -21,7 +21,7 @@ final class PhotoUseCase {
 extension PhotoUseCase {
     func fetch() -> Observable<Photos> {
         return photoRepository.fetch()
-            .flatMap { assets -> Observable<[UIImage]> in
+            .flatMap { assets -> Observable<[UIImage?]> in
                 let observables = assets.map { asset in
                     ImageManager.shard.requestImage(
                         asset: asset,

--- a/PhotoOverlay/Presentation/AlbumList/View/AlbumListTableViewCell.swift
+++ b/PhotoOverlay/Presentation/AlbumList/View/AlbumListTableViewCell.swift
@@ -15,6 +15,8 @@ final class AlbumListTableViewCell: UITableViewCell {
     
     private let thumbnailImageView: UIImageView = {
         let imageView = UIImageView()
+        imageView.layer.cornerRadius = 12
+        imageView.layer.masksToBounds = true
         
         return imageView
     }()

--- a/PhotoOverlay/Presentation/AlbumList/View/AlbumListViewController.swift
+++ b/PhotoOverlay/Presentation/AlbumList/View/AlbumListViewController.swift
@@ -120,10 +120,3 @@ private extension UITableView {
         )
     }
 }
-
-// 임시
-
-struct AlbumItem: Hashable {
-    let title: String
-    let thumbnailImage: UIImage?
-}

--- a/PhotoOverlay/Presentation/AlbumList/View/AlbumListViewController.swift
+++ b/PhotoOverlay/Presentation/AlbumList/View/AlbumListViewController.swift
@@ -26,15 +26,10 @@ final class AlbumListViewController: UIViewController {
     
     private let albumListView = AlbumListView()
     
-    // 임시
+    // MARK: - Properties
     
-    private let albums: [AlbumItem] = [
-        AlbumItem(title: "1", thumbnailImage: UIImage(systemName: "heart")),
-        AlbumItem(title: "2", thumbnailImage: UIImage(systemName: "heart")),
-        AlbumItem(title: "3", thumbnailImage: UIImage(systemName: "heart")),
-        AlbumItem(title: "4", thumbnailImage: UIImage(systemName: "heart")),
-        AlbumItem(title: "5", thumbnailImage: UIImage(systemName: "heart"))
-    ]
+    private let viewModel = AlbumListViewModel()
+    private var disposeBag = DisposeBag()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -43,7 +38,28 @@ final class AlbumListViewController: UIViewController {
         configureSubViews()
         
         configureTableViewDataSource()
-        applySnapShot(albums)
+        
+        bindViewModel()
+    }
+}
+
+// MARK: - Bind
+
+extension AlbumListViewController {
+    private func bindViewModel() {
+        let input = AlbumListViewModel.Input(
+            viewWillAppear: self.rx.viewWillAppear.asObservable()
+        )
+        
+        let output = viewModel.transform(input)
+        
+        output.itemsObservable
+            .observe(on: MainScheduler.asyncInstance)
+            .withUnretained(self)
+            .subscribe(onNext: { (owner, items) in
+                owner.applySnapShot(items)
+            })
+            .disposed(by: disposeBag)
     }
 }
 

--- a/PhotoOverlay/Presentation/AlbumList/ViewModel/AlbumItem.swift
+++ b/PhotoOverlay/Presentation/AlbumList/ViewModel/AlbumItem.swift
@@ -1,0 +1,13 @@
+//
+//  AlbumItem.swift
+//  PhotoOverlay
+//
+//  Created by 황제하 on 2022/07/06.
+//
+
+import Foundation
+
+struct AlbumItem: Hashable {
+    let title: String
+    let thumbnailImage: UIImage?
+}

--- a/PhotoOverlay/Presentation/AlbumList/ViewModel/AlbumItem.swift
+++ b/PhotoOverlay/Presentation/AlbumList/ViewModel/AlbumItem.swift
@@ -5,7 +5,7 @@
 //  Created by 황제하 on 2022/07/06.
 //
 
-import Foundation
+import UIKit
 
 struct AlbumItem: Hashable {
     let title: String

--- a/PhotoOverlay/Presentation/AlbumList/ViewModel/AlbumListViewModel.swift
+++ b/PhotoOverlay/Presentation/AlbumList/ViewModel/AlbumListViewModel.swift
@@ -38,11 +38,13 @@ final class AlbumListViewModel: ViewModel {
         let itemsObservable = input.viewWillAppear
             .withUnretained(self)
             .flatMap { (owner, _) in
-                owner.useCase.fetch()
+                owner.useCase.fetchAlbum()
             }
             .map {
                 $0.map {
                     $0.toItem()
+                }.filter {
+                    $0.thumbnailImage != nil
                 }
             }
         

--- a/PhotoOverlay/Presentation/AlbumList/ViewModel/AlbumListViewModel.swift
+++ b/PhotoOverlay/Presentation/AlbumList/ViewModel/AlbumListViewModel.swift
@@ -21,20 +21,33 @@ final class AlbumListViewModel: ViewModel {
     // MARK: - Output
     
     struct Output {
-        
+        let itemsObservable: Observable<[AlbumItem]>
     }
     
     // MARK: - Properties
     
+    private let useCase: AlbumUseCase
     
     // MARK: - Initializer
     
-    init() {
-        
+    init(useCase: AlbumUseCase = AlbumUseCase()) {
+        self.useCase = useCase
     }
     
     func transform(_ input: Input) -> Output {
+        let itemsObservable = input.viewWillAppear
+            .withUnretained(self)
+            .flatMap { (owner, _) in
+                owner.useCase.fetch()
+            }
+            .map {
+                $0.map {
+                    $0.toItem()
+                }
+            }
         
-        return Output()
+        return Output(
+            itemsObservable: itemsObservable
+        )
     }
 }

--- a/PhotoOverlay/Presentation/AlbumList/ViewModel/AlbumListViewModel.swift
+++ b/PhotoOverlay/Presentation/AlbumList/ViewModel/AlbumListViewModel.swift
@@ -1,0 +1,40 @@
+//
+//  AlbumListViewModel.swift
+//  PhotoOverlay
+//
+//  Created by 황제하 on 2022/07/06.
+//
+
+import Foundation
+import Photos
+
+import RxSwift
+
+final class AlbumListViewModel: ViewModel {
+    
+    // MARK: - Input
+    
+    struct Input {
+        let viewWillAppear: Observable<Void>
+    }
+    
+    // MARK: - Output
+    
+    struct Output {
+        
+    }
+    
+    // MARK: - Properties
+    
+    
+    // MARK: - Initializer
+    
+    init() {
+        
+    }
+    
+    func transform(_ input: Input) -> Output {
+        
+        return Output()
+    }
+}

--- a/PhotoOverlay/Presentation/AlbumList/ViewModel/AlbumListViewModel.swift
+++ b/PhotoOverlay/Presentation/AlbumList/ViewModel/AlbumListViewModel.swift
@@ -35,7 +35,7 @@ final class AlbumListViewModel: ViewModel {
     }
     
     func transform(_ input: Input) -> Output {
-        let itemsObservable = input.viewWillAppear
+        let albumsObservable = input.viewWillAppear
             .withUnretained(self)
             .flatMap { (owner, _) in
                 owner.useCase.fetchAlbum()
@@ -46,6 +46,24 @@ final class AlbumListViewModel: ViewModel {
                 }.filter {
                     $0.thumbnailImage != nil
                 }
+            }
+        
+        let allPhotosAlbumObservable = input.viewWillAppear
+            .withUnretained(self)
+            .flatMap { (owner, _) in
+                owner.useCase.fetchAllPhotosAlbum()
+            }
+            .map { $0.toItem() }
+        
+        let itemsObservable = Observable.combineLatest(
+                albumsObservable,
+                allPhotosAlbumObservable
+            )
+            .map { albums, allPhotosAlbum -> [AlbumItem] in
+                var items = albums
+                items.insert(allPhotosAlbum, at: 0)
+                
+                return items
             }
         
         return Output(

--- a/PhotoOverlay/Presentation/AlbumList/ViewModel/AlbumListViewModel.swift
+++ b/PhotoOverlay/Presentation/AlbumList/ViewModel/AlbumListViewModel.swift
@@ -16,12 +16,14 @@ final class AlbumListViewModel: ViewModel {
     
     struct Input {
         let viewWillAppear: Observable<Void>
+        let selectedAlbumTitle: Observable<String>
     }
     
     // MARK: - Output
     
     struct Output {
         let itemsObservable: Observable<[AlbumItem]>
+        let selectedAlbumObservable: Observable<Album?>
     }
     
     // MARK: - Properties
@@ -40,6 +42,8 @@ final class AlbumListViewModel: ViewModel {
             .flatMap { (owner, _) in
                 owner.useCase.fetchAlbum()
             }
+            
+        let albumItemsObservable = albumsObservable
             .map {
                 $0.map {
                     $0.toItem()
@@ -56,7 +60,7 @@ final class AlbumListViewModel: ViewModel {
             .map { $0.toItem() }
         
         let itemsObservable = Observable.combineLatest(
-                albumsObservable,
+                albumItemsObservable,
                 allPhotosAlbumObservable
             )
             .map { albums, allPhotosAlbum -> [AlbumItem] in
@@ -66,8 +70,20 @@ final class AlbumListViewModel: ViewModel {
                 return items
             }
         
+        let selectedAlbumObservable = Observable.combineLatest(
+                albumsObservable,
+                input.selectedAlbumTitle
+            )
+            .map { albums, title in
+                albums.filter {
+                    $0.title == title
+                }
+                .first
+            }
+            
         return Output(
-            itemsObservable: itemsObservable
+            itemsObservable: itemsObservable,
+            selectedAlbumObservable: selectedAlbumObservable
         )
     }
 }

--- a/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
+++ b/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
@@ -29,7 +29,7 @@ final class PhotosViewController: UIViewController {
     
     // MARK: - Child View Controller
     
-    private let albumListViewController = AlbumListViewController()
+    private var albumListViewController: AlbumListViewController?
     
     // MARK: - Properties
     
@@ -46,14 +46,6 @@ final class PhotosViewController: UIViewController {
         
         bindViewModel()
         bindShowAlbumListButton()
-        
-        PhotoManager.shared.fetchCollections()
-            .subscribe(onNext: {
-                $0.forEach {
-                    print($0.localizedTitle)
-                }
-            })
-            .disposed(by: disposeBag)
     }
 }
 
@@ -83,14 +75,20 @@ extension PhotosViewController {
             .withUnretained(self)
             .subscribe(onNext: { (owner, isShow) in
                 if isShow {
-                    owner.view.addSubview(owner.albumListViewController.view)
+                    owner.albumListViewController = AlbumListViewController()
+                    guard let albumListViewController = owner.albumListViewController else {
+                        return
+                    }
                     
-                    owner.albumListViewController.view.snp.makeConstraints { make in
+                    owner.view.addSubview(albumListViewController.view)
+                    
+                    albumListViewController.view.snp.makeConstraints { make in
                         make.top.equalTo(owner.photosView.photoListCollectionView.snp.top).inset(-8)
                         make.left.trailing.bottom.equalToSuperview()
                     }
                 } else {
-                    owner.albumListViewController.view.removeFromSuperview()
+                    owner.albumListViewController?.view.removeFromSuperview()
+                    owner.albumListViewController = nil
                 }
             })
             .disposed(by: disposeBag)

--- a/PhotoOverlay/Presentation/PhotoList/ViewModel/PhotoItem.swift
+++ b/PhotoOverlay/Presentation/PhotoList/ViewModel/PhotoItem.swift
@@ -8,5 +8,5 @@
 import UIKit
 
 struct PhotoItem: Hashable {
-    let photo: UIImage
+    let photo: UIImage?
 }

--- a/PhotoOverlay/Service/ImageManager/ImageManager.swift
+++ b/PhotoOverlay/Service/ImageManager/ImageManager.swift
@@ -24,11 +24,15 @@ final class ImageManager {
 
 extension ImageManager: ImageRequestable {
     func requestImage(
-        asset: PHAsset,
+        asset: PHAsset?,
         contentMode: PHImageContentMode,
         isThumbnail: Bool = true
-    ) -> Observable<UIImage> {
-        return Observable<UIImage>.create { [weak self] emitter in
+    ) -> Observable<UIImage?> {
+        guard let asset = asset else {
+            return Observable<UIImage?>.just(nil)
+        }
+        
+        return Observable<UIImage?>.create { [weak self] emitter in
             let targetSize = CGSize(width: asset.pixelWidth, height: asset.pixelHeight)
             
             let requestID = self?.phImageManager.requestImage(

--- a/PhotoOverlay/Service/ImageManager/Protocol/ImageRequestable.swift
+++ b/PhotoOverlay/Service/ImageManager/Protocol/ImageRequestable.swift
@@ -13,8 +13,8 @@ import RxSwift
 protocol ImageRequestable {
     // PHAsset -> UIImage 요청 메서드
     func requestImage(
-        asset: PHAsset,
+        asset: PHAsset?,
         contentMode: PHImageContentMode,
         isThumbnail: Bool
-    ) -> Observable<UIImage>
+    ) -> Observable<UIImage?>
 }

--- a/PhotoOverlay/Service/PhotoManager/PhotoManager.swift
+++ b/PhotoOverlay/Service/PhotoManager/PhotoManager.swift
@@ -85,7 +85,7 @@ extension PhotoManager: PhotoFetchable {
     ) -> Observable<PHAsset?> {
         return Observable<PHAsset?>.create { emitter in
             let fetchResult = PHAsset.fetchAssets(in: collection, options: nil)
-            let asset = fetchResult.firstObject
+            let asset = fetchResult.lastObject
             
             emitter.onNext(asset)
             emitter.onCompleted()

--- a/PhotoOverlay/Service/PhotoManager/PhotoManager.swift
+++ b/PhotoOverlay/Service/PhotoManager/PhotoManager.swift
@@ -77,6 +77,22 @@ extension PhotoManager: PhotoFetchable {
             return Disposables.create()
         }
     }
+    
+    /// 앨범 내 첫번째 Asset 가져오기 메서드
+    func fetchFirst(
+        in collection: PHAssetCollection,
+        with mediaType: PHAssetMediaType = .image
+    ) -> Observable<PHAsset?> {
+        return Observable<PHAsset?>.create { emitter in
+            let fetchResult = PHAsset.fetchAssets(in: collection, options: nil)
+            let asset = fetchResult.firstObject
+            
+            emitter.onNext(asset)
+            emitter.onCompleted()
+            
+            return Disposables.create()
+        }
+    }
         
     /// 전체 Asset 가져오기 메서드
     func fetch(

--- a/PhotoOverlay/Service/PhotoManager/Protocol/PhotoFetchable.swift
+++ b/PhotoOverlay/Service/PhotoManager/Protocol/PhotoFetchable.swift
@@ -20,6 +20,12 @@ protocol PhotoFetchable {
         with mediaType: PHAssetMediaType
     ) -> Observable<[PHAsset]>
     
+    /// 앨범 내 첫번째 Asset 가져오기 메서드
+    func fetchFirst(
+        in collection: PHAssetCollection,
+        with mediaType: PHAssetMediaType
+    ) -> Observable<PHAsset?>
+    
     /// 앨범 사진 가져오기 메서드
     func fetch(mediaType: PHAssetMediaType) -> Observable<[PHAsset]>
 }


### PR DESCRIPTION
### 구현 

**- Domain > Interfaces > Repositories**
  -  **protocol** AlbumRepository 

**- Domain > Interfaces > UseCase**
  -  **class** AlbumUseCase : PHAssetCollection을 도메인 모델로 맵핑

**- Data > Repositories**
  - **class** DefaultAlbumRepositoryt : 기기에서 PHAssetCollection을 가져옴.

**Presentation > PhotoList > ViewModel**
  - **class** AlbumListViewModel : ViewModel 프로토콜 채택

 