### PR TITLE
앨범 선택 시 사진 리스트 변경

### DIFF
--- a/PhotoOverlay/Data/Repositories/DefaultPhotoRepository.swift
+++ b/PhotoOverlay/Data/Repositories/DefaultPhotoRepository.swift
@@ -22,4 +22,14 @@ extension DefaultPhotoRepository: PhotoRepository {
     func fetch() -> Observable<[PHAsset]> {
         return photoManager.fetch(mediaType: .image)
     }
+    
+    func fetch(
+        in collection: PHAssetCollection,
+        with mediaType: PHAssetMediaType
+    ) -> Observable<[PHAsset]> {
+        return photoManager.fetch(
+            in: collection,
+            with: mediaType
+        )
+    }
 }

--- a/PhotoOverlay/Domain/Interfaces/Repositorise/PhotoRepository.swift
+++ b/PhotoOverlay/Domain/Interfaces/Repositorise/PhotoRepository.swift
@@ -12,4 +12,9 @@ import RxSwift
 
 protocol PhotoRepository {
     func fetch() -> Observable<[PHAsset]>
+    
+    func fetch(
+        in collection: PHAssetCollection,
+        with mediaType: PHAssetMediaType
+    ) -> Observable<[PHAsset]>
 }

--- a/PhotoOverlay/Domain/UseCase/PhotoUseCase.swift
+++ b/PhotoOverlay/Domain/UseCase/PhotoUseCase.swift
@@ -33,4 +33,19 @@ extension PhotoUseCase {
             }
             .map { Photos(photos: $0) }
     }
+    
+    func fetch(in collection: PHAssetCollection) -> Observable<Photos> {
+        return photoRepository.fetch(in: collection, with: .image)
+            .flatMap { assets -> Observable<[UIImage?]> in
+                let observables = assets.map { asset in
+                    ImageManager.shard.requestImage(
+                        asset: asset,
+                        contentMode: .aspectFit
+                    )
+                }
+                
+                return Observable.combineLatest(observables)
+            }
+            .map { Photos(photos: $0) }
+    }
 }

--- a/PhotoOverlay/Presentation/AlbumList/View/AlbumListView.swift
+++ b/PhotoOverlay/Presentation/AlbumList/View/AlbumListView.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import SnapKit
+
 final class AlbumListView: UIView {
     
     // MARK: - View Properties

--- a/PhotoOverlay/Presentation/AlbumList/View/AlbumListViewController.swift
+++ b/PhotoOverlay/Presentation/AlbumList/View/AlbumListViewController.swift
@@ -12,6 +12,10 @@ import RxRelay
 import RxCocoa
 import SnapKit
 
+protocol AlbumListViewControllerDelegate: AnyObject {
+    func AlbumListViewController(didSelectedAlbum: Album?)
+}
+
 final class AlbumListViewController: UIViewController {
 
     // MARK: - Collection View
@@ -22,6 +26,10 @@ final class AlbumListViewController: UIViewController {
     
     private typealias DiffableDataSource = UITableViewDiffableDataSource<Section, AlbumItem>
     private var dataSource: DiffableDataSource?
+    
+    // MARK: - Delegate
+    
+    weak var delegate: AlbumListViewControllerDelegate?
     
     // MARK: - Views
     
@@ -35,10 +43,6 @@ final class AlbumListViewController: UIViewController {
     // MARK: - Relay
     
     private let selectedAlbumTitleRelay = PublishRelay<String>()
-    
-    deinit {
-        print("디이닛")
-    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -76,7 +80,7 @@ extension AlbumListViewController {
             .observe(on: MainScheduler.asyncInstance)
             .withUnretained(self)
             .subscribe(onNext: { (owner, album) in
-                print(album?.assetCollection)
+                owner.delegate?.AlbumListViewController(didSelectedAlbum: album)
             })
             .disposed(by: disposeBag)
     }

--- a/PhotoOverlay/Presentation/PhotoList/View/PhotosView.swift
+++ b/PhotoOverlay/Presentation/PhotoList/View/PhotosView.swift
@@ -65,11 +65,21 @@ final class PhotosView: UIView {
     }
 }
 
-// MARK: - Configure View
+// MARK: - Update View
 
 extension PhotosView {
     func updateAlbumTitle(_ title: String) {
         showAlbumListButtonLabel.text = title
+    }
+    
+    func showAlbumListButtonAccessoryAnimation(isShow: Bool) {
+        UIView.animate(withDuration: 0.5) {
+            if isShow {
+                self.showAlbumListButtonAccessory.transform = CGAffineTransform(rotationAngle: .pi)
+            } else {
+                self.showAlbumListButtonAccessory.transform = CGAffineTransform(rotationAngle: 0)
+            }
+        }
     }
 }
 

--- a/PhotoOverlay/Presentation/PhotoList/View/PhotosView.swift
+++ b/PhotoOverlay/Presentation/PhotoList/View/PhotosView.swift
@@ -68,6 +68,14 @@ final class PhotosView: UIView {
 // MARK: - Configure View
 
 extension PhotosView {
+    func updateAlbumTitle(_ title: String) {
+        showAlbumListButtonLabel.text = title
+    }
+}
+
+// MARK: - Configure View
+
+extension PhotosView {
     private func configureSubviews() {
         
         // MARK: - Constraints AlbumListButton & Accessory

--- a/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
+++ b/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
@@ -109,6 +109,8 @@ extension PhotosViewController {
                 } else {
                     owner.hideAlbumList()
                 }
+                
+                owner.photosView.showAlbumListButtonAccessoryAnimation(isShow: isShow)
             })
             .disposed(by: disposeBag)
     }

--- a/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
+++ b/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
@@ -144,7 +144,7 @@ extension PhotosViewController {
     }
 }
 
-// MARK: - Delegate
+// MARK: - AlbumListViewController Delegate
 
 extension PhotosViewController: AlbumListViewControllerDelegate {
     func AlbumListViewController(didSelectedAlbum: Album?) {

--- a/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
+++ b/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
@@ -39,6 +39,7 @@ final class PhotosViewController: UIViewController {
     // MARK: - Relay
     
     private let selectedAlbumRelay = PublishRelay<Album?>()
+    private let showAlbumListGestureRelay = PublishRelay<Bool>()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -95,6 +96,14 @@ extension PhotosViewController {
             .scan(false) { lastState, _ in !lastState }
             .withUnretained(self)
             .subscribe(onNext: { (owner, isShow) in
+                owner.showAlbumListGestureRelay.accept(isShow)
+            })
+            .disposed(by: disposeBag)
+        
+        showAlbumListGestureRelay.asObservable()
+            .scan(false) { lastState, _ in !lastState }
+            .withUnretained(self)
+            .subscribe(onNext: { (owner, isShow) in
                 if isShow {
                     owner.showAlbumList()
                 } else {
@@ -137,7 +146,7 @@ extension PhotosViewController {
 
 extension PhotosViewController: AlbumListViewControllerDelegate {
     func AlbumListViewController(didSelectedAlbum: Album?) {
-        hideAlbumList()
+        showAlbumListGestureRelay.accept(false)
         selectedAlbumRelay.accept(didSelectedAlbum)
     }
 }

--- a/PhotoOverlay/Presentation/PhotoList/ViewModel/PhotosViewModel.swift
+++ b/PhotoOverlay/Presentation/PhotoList/ViewModel/PhotosViewModel.swift
@@ -16,7 +16,7 @@ final class PhotosViewModel: ViewModel {
     
     struct Input {
         let viewWillAppear: Observable<Void>
-        let albumAsset: Observable<Album>
+        let albumAsset: Observable<Album?>
     }
     
     // MARK: - Output
@@ -50,7 +50,9 @@ final class PhotosViewModel: ViewModel {
         let itemsInAlbumObservable = input.albumAsset
             .withUnretained(self)
             .flatMap { (owner, album) -> Observable<Photos> in
-                guard let collection = album.assetCollection else {
+                guard let album = album,
+                      let collection = album.assetCollection
+                else {
                     return owner.useCase.fetch()
                 }
                 
@@ -61,8 +63,14 @@ final class PhotosViewModel: ViewModel {
             }
         
         let albumTitleObservable = input.albumAsset
-            .compactMap { album in
-                album.title
+            .map { album -> String in
+                guard let album = album,
+                      let title = album.title
+                else {
+                    return "All Photos"
+                }
+                
+                return title
             }
         
         return Output(

--- a/PhotoOverlay/Presentation/PhotoList/ViewModel/PhotosViewModel.swift
+++ b/PhotoOverlay/Presentation/PhotoList/ViewModel/PhotosViewModel.swift
@@ -16,6 +16,7 @@ final class PhotosViewModel: ViewModel {
     
     struct Input {
         let viewWillAppear: Observable<Void>
+        let albumAsset: Observable<Album>
     }
     
     // MARK: - Output
@@ -42,6 +43,12 @@ final class PhotosViewModel: ViewModel {
             }
             .map {
                 $0.toItem()
+            }
+        
+        let itemsInAlbumObservable = input.viewWillAppear
+            .withUnretained(self)
+            .flatMap { (owner, asset) in
+                owner.useCase.
             }
         
         return Output(


### PR DESCRIPTION
### 구현 화면
![Simulator Screen Recording - iPhone 13 - 2022-07-07 at 12 47 12](https://user-images.githubusercontent.com/98801129/177686453-9a8a66c6-7464-46a3-a2f2-ce4e4ba5fd6b.gif)

### 구현
- **AlbumListViewController**의 Delegate로 **PhotosViewController** 지정 (**AlbumListViewControllerDelegate** 프로토콜 사용)
- 앨범 선택 시 도메인 모델(Album)을 전달