### PR TITLE
Coordinator 패턴 적용(PhotoListView -> PhotoOverlayView)

### DIFF
--- a/PhotoOverlay.xcodeproj/project.pbxproj
+++ b/PhotoOverlay.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		08B5A434287890AE0036C4F4 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A433287890AE0036C4F4 /* Coordinator.swift */; };
 		08B5A436287890F40036C4F4 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A435287890F40036C4F4 /* AppCoordinator.swift */; };
 		08B5A439287891770036C4F4 /* PhotoListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A438287891770036C4F4 /* PhotoListCoordinator.swift */; };
+		08B5A43B2878934F0036C4F4 /* PhotoOverlayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A43A2878934F0036C4F4 /* PhotoOverlayCoordinator.swift */; };
 		08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78ADE286EE499006296DE /* AppDelegate.swift */; };
 		08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE0286EE499006296DE /* SceneDelegate.swift */; };
 		08C78AE9286EE499006296DE /* PhotoOverlay.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE7286EE499006296DE /* PhotoOverlay.xcdatamodeld */; };
@@ -123,6 +124,7 @@
 		08B5A433287890AE0036C4F4 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		08B5A435287890F40036C4F4 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		08B5A438287891770036C4F4 /* PhotoListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoListCoordinator.swift; sourceTree = "<group>"; };
+		08B5A43A2878934F0036C4F4 /* PhotoOverlayCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoOverlayCoordinator.swift; sourceTree = "<group>"; };
 		08C78ADB286EE499006296DE /* PhotoOverlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoOverlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		08C78ADE286EE499006296DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		08C78AE0286EE499006296DE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -360,6 +362,7 @@
 				08B5A432287890850036C4F4 /* Protocol */,
 				08B5A435287890F40036C4F4 /* AppCoordinator.swift */,
 				08B5A438287891770036C4F4 /* PhotoListCoordinator.swift */,
+				08B5A43A2878934F0036C4F4 /* PhotoOverlayCoordinator.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -725,6 +728,7 @@
 				0817A9B12872CDC300C821DD /* PhotoListCollectionViewCell.swift in Sources */,
 				08B5A4262878568E0036C4F4 /* PhotoOverlayImageView.swift in Sources */,
 				0898ABCB2876AD0000E0035A /* SVGListCollectionViewCell.swift in Sources */,
+				08B5A43B2878934F0036C4F4 /* PhotoOverlayCoordinator.swift in Sources */,
 				08A1D49F2873FD0D00490129 /* ViewModel.swift in Sources */,
 				08A1D4BD287550C000490129 /* AlbumListTableViewCell.swift in Sources */,
 				08A1D4C42875666200490129 /* AlbumUseCase.swift in Sources */,

--- a/PhotoOverlay.xcodeproj/project.pbxproj
+++ b/PhotoOverlay.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		08B5A42C287882130036C4F4 /* Observable+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A42B287882130036C4F4 /* Observable+extension.swift */; };
 		08B5A42E287886310036C4F4 /* SavePhotoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A42D287886310036C4F4 /* SavePhotoRepository.swift */; };
 		08B5A43028788C750036C4F4 /* PhotoRepositorySavable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A42F28788C750036C4F4 /* PhotoRepositorySavable.swift */; };
+		08B5A434287890AE0036C4F4 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A433287890AE0036C4F4 /* Coordinator.swift */; };
 		08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78ADE286EE499006296DE /* AppDelegate.swift */; };
 		08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE0286EE499006296DE /* SceneDelegate.swift */; };
 		08C78AE9286EE499006296DE /* PhotoOverlay.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE7286EE499006296DE /* PhotoOverlay.xcdatamodeld */; };
@@ -117,6 +118,7 @@
 		08B5A42B287882130036C4F4 /* Observable+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+extension.swift"; sourceTree = "<group>"; };
 		08B5A42D287886310036C4F4 /* SavePhotoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavePhotoRepository.swift; sourceTree = "<group>"; };
 		08B5A42F28788C750036C4F4 /* PhotoRepositorySavable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoRepositorySavable.swift; sourceTree = "<group>"; };
+		08B5A433287890AE0036C4F4 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		08C78ADB286EE499006296DE /* PhotoOverlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoOverlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		08C78ADE286EE499006296DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		08C78AE0286EE499006296DE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -348,6 +350,22 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		08B5A4312878907F0036C4F4 /* Coordinator */ = {
+			isa = PBXGroup;
+			children = (
+				08B5A432287890850036C4F4 /* Protocol */,
+			);
+			path = Coordinator;
+			sourceTree = "<group>";
+		};
+		08B5A432287890850036C4F4 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				08B5A433287890AE0036C4F4 /* Coordinator.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		08C78AD2286EE499006296DE = {
 			isa = PBXGroup;
 			children = (
@@ -405,6 +423,7 @@
 		08C78AF728703916006296DE /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				08B5A4312878907F0036C4F4 /* Coordinator */,
 				08A1D4A02873FD1400490129 /* Common */,
 				08A1D49B2873FC7400490129 /* PhotoList */,
 				08A1D4B628753AE800490129 /* AlbumList */,
@@ -710,6 +729,7 @@
 				08B5A43028788C750036C4F4 /* PhotoRepositorySavable.swift in Sources */,
 				08C78B0E28704483006296DE /* PhotoAuthorizationable.swift in Sources */,
 				0898ABD72876CEF800E0035A /* LoadSVGRepository.swift in Sources */,
+				08B5A434287890AE0036C4F4 /* Coordinator.swift in Sources */,
 				08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */,
 				0898ABC92876A98600E0035A /* PhotoOverlayView.swift in Sources */,
 				0898ABE12876D47200E0035A /* PhotoOverlayUseCase.swift in Sources */,

--- a/PhotoOverlay.xcodeproj/project.pbxproj
+++ b/PhotoOverlay.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		08B5A42E287886310036C4F4 /* SavePhotoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A42D287886310036C4F4 /* SavePhotoRepository.swift */; };
 		08B5A43028788C750036C4F4 /* PhotoRepositorySavable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A42F28788C750036C4F4 /* PhotoRepositorySavable.swift */; };
 		08B5A434287890AE0036C4F4 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A433287890AE0036C4F4 /* Coordinator.swift */; };
+		08B5A436287890F40036C4F4 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A435287890F40036C4F4 /* AppCoordinator.swift */; };
 		08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78ADE286EE499006296DE /* AppDelegate.swift */; };
 		08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE0286EE499006296DE /* SceneDelegate.swift */; };
 		08C78AE9286EE499006296DE /* PhotoOverlay.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE7286EE499006296DE /* PhotoOverlay.xcdatamodeld */; };
@@ -119,6 +120,7 @@
 		08B5A42D287886310036C4F4 /* SavePhotoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavePhotoRepository.swift; sourceTree = "<group>"; };
 		08B5A42F28788C750036C4F4 /* PhotoRepositorySavable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoRepositorySavable.swift; sourceTree = "<group>"; };
 		08B5A433287890AE0036C4F4 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
+		08B5A435287890F40036C4F4 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		08C78ADB286EE499006296DE /* PhotoOverlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoOverlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		08C78ADE286EE499006296DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		08C78AE0286EE499006296DE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -354,6 +356,7 @@
 			isa = PBXGroup;
 			children = (
 				08B5A432287890850036C4F4 /* Protocol */,
+				08B5A435287890F40036C4F4 /* AppCoordinator.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -697,6 +700,7 @@
 			files = (
 				08C78AE9286EE499006296DE /* PhotoOverlay.xcdatamodeld in Sources */,
 				089A8D5428718AAE00AC4873 /* ImageRequestable.swift in Sources */,
+				08B5A436287890F40036C4F4 /* AppCoordinator.swift in Sources */,
 				08A1D4C628756E9A00490129 /* AlbumRepositoryFetchable.swift in Sources */,
 				0898ABDD2876D37B00E0035A /* SVGImageSetDTO.swift in Sources */,
 				0898ABDF2876D41300E0035A /* SVGImage.swift in Sources */,

--- a/PhotoOverlay.xcodeproj/project.pbxproj
+++ b/PhotoOverlay.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		08B5A43028788C750036C4F4 /* PhotoRepositorySavable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A42F28788C750036C4F4 /* PhotoRepositorySavable.swift */; };
 		08B5A434287890AE0036C4F4 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A433287890AE0036C4F4 /* Coordinator.swift */; };
 		08B5A436287890F40036C4F4 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A435287890F40036C4F4 /* AppCoordinator.swift */; };
+		08B5A439287891770036C4F4 /* PhotoListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B5A438287891770036C4F4 /* PhotoListCoordinator.swift */; };
 		08C78ADF286EE499006296DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78ADE286EE499006296DE /* AppDelegate.swift */; };
 		08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE0286EE499006296DE /* SceneDelegate.swift */; };
 		08C78AE9286EE499006296DE /* PhotoOverlay.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 08C78AE7286EE499006296DE /* PhotoOverlay.xcdatamodeld */; };
@@ -121,6 +122,7 @@
 		08B5A42F28788C750036C4F4 /* PhotoRepositorySavable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoRepositorySavable.swift; sourceTree = "<group>"; };
 		08B5A433287890AE0036C4F4 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		08B5A435287890F40036C4F4 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		08B5A438287891770036C4F4 /* PhotoListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoListCoordinator.swift; sourceTree = "<group>"; };
 		08C78ADB286EE499006296DE /* PhotoOverlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoOverlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		08C78ADE286EE499006296DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		08C78AE0286EE499006296DE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -357,6 +359,7 @@
 			children = (
 				08B5A432287890850036C4F4 /* Protocol */,
 				08B5A435287890F40036C4F4 /* AppCoordinator.swift */,
+				08B5A438287891770036C4F4 /* PhotoListCoordinator.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -740,6 +743,7 @@
 				0898ABCD2876AE4500E0035A /* UICollectionView+extension.swift in Sources */,
 				08C78AFF287039F7006296DE /* PhotoManager.swift in Sources */,
 				0898ABDA2876CF6A00E0035A /* AssetLoadManager.swift in Sources */,
+				08B5A439287891770036C4F4 /* PhotoListCoordinator.swift in Sources */,
 				08C78AE1286EE499006296DE /* SceneDelegate.swift in Sources */,
 				0898ABD12876C41E00E0035A /* SVGItem.swift in Sources */,
 				08A1D4C2287563D800490129 /* FetchAlbumRepository.swift in Sources */,

--- a/PhotoOverlay/Application/SceneDelegate.swift
+++ b/PhotoOverlay/Application/SceneDelegate.swift
@@ -10,17 +10,17 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    private var appCoordinator: AppCoordinator?
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let scene = (scene as? UIWindowScene) else { return }
         
+        let navigationController = UINavigationController()
+        appCoordinator = AppCoordinator(navigationController: navigationController)
+        appCoordinator?.start()
+        
         window = UIWindow(windowScene: scene)
-        let rootViweController = PhotosViewController()
-//        let rootViweController = PhotoOverlayViewController()
-        let navigationController = UINavigationController(
-            rootViewController: rootViweController
-        )
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
     }

--- a/PhotoOverlay/Presentation/Coordinator/AppCoordinator.swift
+++ b/PhotoOverlay/Presentation/Coordinator/AppCoordinator.swift
@@ -33,6 +33,10 @@ final class AppCoordinator: Coordinator {
     }
     
     func showPhotoOverlayView() {
-        
+        let photoListCoordinator = PhotoOverlayCoordinator(
+            parentCoordinator: self,
+            navigationController: navigationController
+        )
+        photoListCoordinator.start()
     }
 }

--- a/PhotoOverlay/Presentation/Coordinator/AppCoordinator.swift
+++ b/PhotoOverlay/Presentation/Coordinator/AppCoordinator.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Photos
 
 final class AppCoordinator: Coordinator {
     
@@ -29,14 +30,17 @@ final class AppCoordinator: Coordinator {
             parentCoordinator: self,
             navigationController: navigationController
         )
+        childCoordinators.append(photoListCoordinator)
         photoListCoordinator.start()
     }
     
-    func showPhotoOverlayView() {
-        let photoListCoordinator = PhotoOverlayCoordinator(
+    func showPhotoOverlayView(_ asset: PHAsset) {
+        let photoOverlayCoordinator = PhotoOverlayCoordinator(
+            asset: asset,
             parentCoordinator: self,
             navigationController: navigationController
         )
-        photoListCoordinator.start()
+        childCoordinators.append(photoOverlayCoordinator)
+        photoOverlayCoordinator.start()
     }
 }

--- a/PhotoOverlay/Presentation/Coordinator/AppCoordinator.swift
+++ b/PhotoOverlay/Presentation/Coordinator/AppCoordinator.swift
@@ -25,7 +25,11 @@ final class AppCoordinator: Coordinator {
     }
     
     func showPhotoListView() {
-        
+        let photoListCoordinator = PhotoListCoordinator(
+            parentCoordinator: self,
+            navigationController: navigationController
+        )
+        photoListCoordinator.start()
     }
     
     func showPhotoOverlayView() {

--- a/PhotoOverlay/Presentation/Coordinator/AppCoordinator.swift
+++ b/PhotoOverlay/Presentation/Coordinator/AppCoordinator.swift
@@ -1,0 +1,34 @@
+//
+//  AppCoordinator.swift
+//  PhotoOverlay
+//
+//  Created by 황제하 on 2022/07/09.
+//
+
+import UIKit
+
+final class AppCoordinator: Coordinator {
+    
+    // MARK: - Coordinator Property
+    
+    var childCoordinators: [Coordinator] = []
+    var navigationController: UINavigationController
+    
+    init(
+        navigationController: UINavigationController = UINavigationController()
+    ) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        showPhotoListView()
+    }
+    
+    func showPhotoListView() {
+        
+    }
+    
+    func showPhotoOverlayView() {
+        
+    }
+}

--- a/PhotoOverlay/Presentation/Coordinator/PhotoListCoordinator.swift
+++ b/PhotoOverlay/Presentation/Coordinator/PhotoListCoordinator.swift
@@ -1,0 +1,31 @@
+//
+//  PhotoListCoordinator.swift
+//  PhotoOverlay
+//
+//  Created by 황제하 on 2022/07/09.
+//
+
+import UIKit
+
+final class PhotoListCoordinator: Coordinator {
+        
+    // MARK: - Coordinator Property
+    
+    private weak var parentCoordinator: AppCoordinator?
+    var childCoordinators: [Coordinator] = []
+    var navigationController: UINavigationController
+    
+    init(
+        parentCoordinator: AppCoordinator?,
+        navigationController: UINavigationController = UINavigationController()
+    ) {
+        self.parentCoordinator = parentCoordinator
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        let photoListViewController = PhotosViewController()
+        photoListViewController.coordinator = self
+        navigationController.show(photoListViewController, sender: nil)
+    }
+}

--- a/PhotoOverlay/Presentation/Coordinator/PhotoListCoordinator.swift
+++ b/PhotoOverlay/Presentation/Coordinator/PhotoListCoordinator.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Photos
 
 final class PhotoListCoordinator: Coordinator {
         
@@ -29,7 +30,7 @@ final class PhotoListCoordinator: Coordinator {
         navigationController.show(photoListViewController, sender: nil)
     }
     
-    func showPhotoOverlayView() {
-        parentCoordinator?.showPhotoOverlayView()
+    func showPhotoOverlayView(_ asset: PHAsset) {
+        parentCoordinator?.showPhotoOverlayView(asset)
     }
 }

--- a/PhotoOverlay/Presentation/Coordinator/PhotoOverlayCoordinator.swift
+++ b/PhotoOverlay/Presentation/Coordinator/PhotoOverlayCoordinator.swift
@@ -1,5 +1,5 @@
 //
-//  PhotoListCoordinator.swift
+//  PhotoOverlayCoordinator.swift
 //  PhotoOverlay
 //
 //  Created by 황제하 on 2022/07/09.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class PhotoListCoordinator: Coordinator {
+final class PhotoOverlayCoordinator: Coordinator {
         
     // MARK: - Coordinator Property
     
@@ -24,12 +24,12 @@ final class PhotoListCoordinator: Coordinator {
     }
     
     func start() {
-        let photoListViewController = PhotosViewController()
-        photoListViewController.coordinator = self
-        navigationController.show(photoListViewController, sender: nil)
+        let photoOverlayViewController = PhotoOverlayViewController()
+        photoOverlayViewController.coordinator = self
+        navigationController.show(photoOverlayViewController, sender: nil)
     }
     
-    func showPhotoOverlayView() {
-        parentCoordinator?.showPhotoOverlayView()
+    func popPhotoOverlayView() {
+        parentCoordinator?.removeChildCoordinator(self)
     }
 }

--- a/PhotoOverlay/Presentation/Coordinator/PhotoOverlayCoordinator.swift
+++ b/PhotoOverlay/Presentation/Coordinator/PhotoOverlayCoordinator.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Photos
 
 final class PhotoOverlayCoordinator: Coordinator {
         
@@ -15,16 +16,24 @@ final class PhotoOverlayCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
     
+    // MARK: - Property
+    
+    private let asset: PHAsset
+    
     init(
+        asset: PHAsset,
         parentCoordinator: AppCoordinator?,
         navigationController: UINavigationController = UINavigationController()
     ) {
+        self.asset = asset
         self.parentCoordinator = parentCoordinator
         self.navigationController = navigationController
     }
     
     func start() {
+        let photoOverlayViewModel = PhotoOverlayViewModel(asset: asset)
         let photoOverlayViewController = PhotoOverlayViewController()
+        photoOverlayViewController.viewModel = photoOverlayViewModel
         photoOverlayViewController.coordinator = self
         navigationController.show(photoOverlayViewController, sender: nil)
     }

--- a/PhotoOverlay/Presentation/Coordinator/Protocol/Coordinator.swift
+++ b/PhotoOverlay/Presentation/Coordinator/Protocol/Coordinator.swift
@@ -1,0 +1,27 @@
+//
+//  Coordinator.swift
+//  PhotoOverlay
+//
+//  Created by 황제하 on 2022/07/09.
+//
+
+import UIKit
+
+protocol Coordinator: AnyObject {
+    var childCoordinators: [Coordinator] { get set }
+    var navigationController: UINavigationController { get set }
+    
+    func start()
+    func removeChildCoordinator(_ child: Coordinator)
+}
+
+extension Coordinator {
+    func removeChildCoordinator(_ child: Coordinator) {
+        for (index, coordinator) in childCoordinators.enumerated() {
+            if coordinator === child {
+                childCoordinators.remove(at: index)
+                break
+            }
+        }
+    }
+}

--- a/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
+++ b/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
@@ -6,11 +6,11 @@
 //
 
 import UIKit
+import Photos
 
 import RxSwift
 import RxCocoa
 import SnapKit
-import Photos
 
 final class PhotosViewController: UIViewController {
     
@@ -100,12 +100,7 @@ extension PhotosViewController {
             .observe(on: MainScheduler.asyncInstance)
             .withUnretained(self)
             .subscribe(onNext: { (owner, asset) in
-                let photoOverlayViewModel = PhotoOverlayViewModel(asset: asset)
-                
-                let photoOverlayViewController = PhotoOverlayViewController()
-                photoOverlayViewController.viewModel = photoOverlayViewModel
-                
-                owner.show(photoOverlayViewController, sender: nil)
+                owner.coordinator?.showPhotoOverlayView(asset)
             })
             .disposed(by: disposeBag)
     }

--- a/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
+++ b/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
@@ -14,6 +14,10 @@ import Photos
 
 final class PhotosViewController: UIViewController {
     
+    // MARK: - Coordinator
+    
+    weak var coordinator: PhotoListCoordinator?
+    
     // MARK: - Collection View
     
     private enum Section {

--- a/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
+++ b/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
@@ -105,16 +105,6 @@ extension PhotosViewController {
             .disposed(by: disposeBag)
     }
     
-    private func bindCollectionView() {
-        photosView.photoListCollectionView.rx.itemSelected
-            .observe(on: MainScheduler.asyncInstance)
-            .withUnretained(self)
-            .subscribe(onNext: { (owner, indexPath) in
-                
-            })
-            .disposed(by: disposeBag)
-    }
-    
     private func bindShowAlbumListButton() {
         photosView.showAlbumListGesture.rx.event
             .scan(false) { lastState, _ in !lastState }

--- a/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
+++ b/PhotoOverlay/Presentation/PhotoList/View/PhotosViewController.swift
@@ -64,7 +64,6 @@ final class PhotosViewController: UIViewController {
         
         bindViewModel()
         bindShowAlbumListButton()
-        bindCollectionView()
     }
 }
 

--- a/PhotoOverlay/Presentation/PhotoOverlay/View/PhotoOverlayViewController.swift
+++ b/PhotoOverlay/Presentation/PhotoOverlay/View/PhotoOverlayViewController.swift
@@ -13,6 +13,10 @@ import SnapKit
 
 final class PhotoOverlayViewController: UIViewController {
     
+    // MARK: - Coordinator
+    
+    weak var coordinator: PhotoOverlayCoordinator?
+    
     // MARK: - Collection View
     
     private enum Section {
@@ -41,6 +45,8 @@ final class PhotoOverlayViewController: UIViewController {
     var viewModel: PhotoOverlayViewModel?
     private var disposeBag = DisposeBag()
     
+    // MARK: - Life Cycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -55,6 +61,10 @@ final class PhotoOverlayViewController: UIViewController {
         bindViewModel()
         bindRemoveSVGButton()
         bindOverlayButton()
+    }
+    
+    deinit {
+        coordinator?.popPhotoOverlayView()
     }
 }
 


### PR DESCRIPTION
### 구현 
 -  **protocol** Coordinator
   - removeChildCoordinator() : 자식 코디네이터를 메모리에서 해제 시키기 위한 메서드(extension 기본구현)

 -  **class** AppCoordinator : 앱 전반적인 화면 전환을 담당
 -  **class** PhotoListCoordinator : 사진 리스트 뷰의 화면 전환을 담당, 사진 합성 뷰에게 PHAsset를 전달함.
 -  **class** PhotoOverlayCoordinator : 사진 합성 뷰의 화면 전환을 담당, 사진 합성 뷰가 메모리에서 해제 될 시 (deinit) 메모리에서 같이 해제됨.